### PR TITLE
Remove deprecated class

### DIFF
--- a/pycall/callfile.py
+++ b/pycall/callfile.py
@@ -8,7 +8,7 @@ from pwd import getpwnam
 from tempfile import mkstemp
 from os import chown, error, utime
 
-from path import path
+from path import Path
 
 from .call import Call
 from .actions import Action, Context
@@ -44,10 +44,10 @@ class CallFile(object):
         self.spool_dir = spool_dir or self.DEFAULT_SPOOL_DIR
 
         if filename and tempdir:
-            self.filename = path(filename)
-            self.tempdir = path(tempdir)
+            self.filename = Path(filename)
+            self.tempdir = Path(tempdir)
         else:
-            f = path(mkstemp(suffix='.call')[1])
+            f = Path(mkstemp(suffix='.call')[1])
             self.filename = f.name
             self.tempdir = f.parent
 
@@ -73,7 +73,7 @@ class CallFile(object):
                 isinstance(self.action, Context)):
             return False
 
-        if self.spool_dir and not path(self.spool_dir).abspath().isdir():
+        if self.spool_dir and not Path(self.spool_dir).abspath().isdir():
             return False
 
         if not self.call.is_valid():
@@ -112,7 +112,7 @@ class CallFile(object):
 
     def writefile(self):
         """Write a temporary call file to disk."""
-        with open(path(self.tempdir) / path(self.filename), 'w') as f:
+        with open(Path(self.tempdir) / Path(self.filename), 'w') as f:
             f.write(self.contents)
 
     def spool(self, time=None):
@@ -134,7 +134,7 @@ class CallFile(object):
                 gid = pwd[3]
 
                 try:
-                    chown(path(self.tempdir) / path(self.filename), uid, gid)
+                    chown(Path(self.tempdir) / Path(self.filename), uid, gid)
                 except error:
                     raise NoUserPermissionError
             except KeyError:
@@ -143,12 +143,12 @@ class CallFile(object):
         if time:
             try:
                 time = mktime(time.timetuple())
-                utime(path(self.tempdir) / path(self.filename), (time, time))
+                utime(Path(self.tempdir) / Path(self.filename), (time, time))
             except (error, AttributeError, OverflowError, ValueError):
                 raise InvalidTimeError
 
         try:
-            move(path(self.tempdir) / path(self.filename),
-                    path(self.spool_dir) / path(self.filename))
+            move(Path(self.tempdir) / Path(self.filename),
+                    Path(self.spool_dir) / Path(self.filename))
         except IOError:
             raise NoSpoolPermissionError

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     include_package_data = True,
 
     # Package dependencies.
-    install_requires = ['path.py>=2.2.2'],
+    install_requires = ['path.py>=6.2.0'],
     extras_require = {
         'test': ['codacy-coverage', 'python-coveralls', 'pytest', 'pytest-cov', 'sphinx'],
     },

--- a/tests/test_callfile.py
+++ b/tests/test_callfile.py
@@ -5,7 +5,7 @@ from getpass import getuser
 from datetime import datetime
 from unittest import TestCase
 
-from path import path
+from path import Path
 
 from pycall import Application, Call, CallFile, InvalidTimeError, \
     NoSpoolPermissionError, NoUserError, NoUserPermissionError, \
@@ -133,7 +133,7 @@ class TestCallFile(TestCase):
         """
         c = CallFile(self.call, self.action, spool_dir=self.spool_dir)
         c.writefile()
-        self.assertTrue((path(c.tempdir) / path(c.filename)).abspath().exists())
+        self.assertTrue((Path(c.tempdir) / Path(c.filename)).abspath().exists())
 
     def test_spool_no_time_no_user(self):
         """Ensure `spool` works when no `time` attribute is supplied, and no
@@ -141,7 +141,7 @@ class TestCallFile(TestCase):
         """
         c = CallFile(self.call, self.action, spool_dir=self.spool_dir)
         c.spool()
-        self.assertTrue((path(c.spool_dir) / path(c.filename)).abspath().exists())
+        self.assertTrue((Path(c.spool_dir) / Path(c.filename)).abspath().exists())
 
     def test_spool_no_time_no_spool_permission_error(self):
         """Ensure that `spool` raises `NoSpoolPermissionError` if the user
@@ -197,4 +197,4 @@ class TestCallFile(TestCase):
         c = CallFile(self.call, self.action, spool_dir=self.spool_dir)
         d = datetime.now()
         c.spool(d)
-        self.assertEqual((path(c.tempdir) / path(c.filename)).abspath().atime, mktime(d.timetuple()))
+        self.assertEqual((Path(c.tempdir) / Path(c.filename)).abspath().atime, mktime(d.timetuple()))


### PR DESCRIPTION
Fixes #15 

The ```path``` class was deprecated and the compatibility shim removed in the latest release (https://github.com/jaraco/path.py/commit/a781071bf0fc9ff477b2d141baec343a7b3ab0e9)

This PR updates the code accordingly.